### PR TITLE
Sort signal table by score and slim CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -3,42 +3,16 @@ name: Smoke Test
 on:
   pull_request:
 
+concurrency:
+  group: smoke-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
-  known-targets:
-    name: Scan known targets
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        package:
-          - axios
-          - "@anthropic-ai/sdk"
-          - event-stream
-          - ua-parser-js
-          - colors
-          - node-ipc
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: "1.26"
-
-      - name: Build
-        run: go build -o chainrecon ./cmd/chainrecon
-
-      - name: Scan ${{ matrix.package }}
-        run: |
-          ./chainrecon scan "${{ matrix.package }}" --timeout 90s
-          ./chainrecon scan "${{ matrix.package }}" --format json --timeout 90s | jq .scores
-
-  popular:
-    name: Scan popular packages
+  smoke:
+    name: Smoke test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -52,35 +26,21 @@ jobs:
       - name: Build
         run: go build -o chainrecon ./cmd/chainrecon
 
-      - name: Pick random packages from npm
-        id: pick
+      - name: Scan axios (table)
         run: |
-          PACKAGES=$(curl -s "https://registry.npmjs.org/-/v1/search?text=boost-exact:true&popularity=1.0&size=250" \
-            | jq -r '.objects[].package.name' \
-            | shuf -n 5)
+          OUTPUT=$(./chainrecon scan axios --timeout 90s 2>&1)
+          echo "$OUTPUT"
 
-          echo "Picked packages:"
-          echo "$PACKAGES"
-          echo "packages=$(echo "$PACKAGES" | jq -R . | jq -sc .)" >> "$GITHUB_OUTPUT"
+          # Verify table structure is present.
+          echo "$OUTPUT" | grep -q "Package:" || { echo "::error::Missing Package header"; exit 1; }
+          echo "$OUTPUT" | grep -q "Signal" || { echo "::error::Missing Signal table header"; exit 1; }
+          echo "$OUTPUT" | grep -q "Target Score" || { echo "::error::Missing Target Score"; exit 1; }
+          echo "$OUTPUT" | grep -q "Key Findings:" || { echo "::error::Missing Key Findings"; exit 1; }
 
-      - name: Scan packages
+      - name: Scan axios (JSON)
         run: |
-          PACKAGES='${{ steps.pick.outputs.packages }}'
-          FAILED=0
-
-          for pkg in $(echo "$PACKAGES" | jq -r '.[]'); do
-            echo "::group::$pkg"
-            if ./chainrecon scan "$pkg" --timeout 90s && \
-               ./chainrecon scan "$pkg" --format json --timeout 90s | jq .scores; then
-              echo "::endgroup::"
-            else
-              echo "::endgroup::"
-              echo "::warning::scan failed for $pkg"
-              FAILED=1
-            fi
-          done
-
-          if [ "$FAILED" -eq 1 ]; then
-            echo "::error::One or more scans failed"
-            exit 1
-          fi
+          ./chainrecon scan axios --format json --timeout 90s | jq -e '
+            .package == "axios" and
+            .scores.target_score > 0 and
+            (.findings | length) > 0
+          '

--- a/README.md
+++ b/README.md
@@ -23,30 +23,30 @@ $ chainrecon scan axios
  ┌─────────────────────────┬───────────┬─────────────────────────────────────────────┐
  │ Signal                  │ Score     │ Detail                                      │
  ├─────────────────────────┼───────────┼─────────────────────────────────────────────┤
- │ Provenance              │ 7.5/10    │ Provenance is intermittent across versions  │
- │ Publishing Hygiene      │ 5.0/10    │ Mixed publishing methods detected           │
+ │ Blast Radius            │ 10.0/10   │ Extremely high blast radius                 │
  │ Maintainer Risk         │ 9.0/10    │ Single maintainer with full publish access  │
  │ Identity Stability      │ 8.0/10    │ Maintainer email changed between versions   │
+ │ Provenance              │ 7.5/10    │ Provenance is intermittent across versions  │
+ │ Publishing Hygiene      │ 5.0/10    │ Mixed publishing methods detected           │
  │ Scorecard (imported)    │ 4.5/10    │ OpenSSF Scorecard: 5.5/10                   │
- │ Blast Radius            │ 10.0/10   │ Extremely high blast radius                 │
  ├─────────────────────────┼───────────┼─────────────────────────────────────────────┤
  │ Attack Surface          │ 6.9/10    │                                             │
  │ Target Score            │ 69.0      │ HIGH                                        │
  └─────────────────────────┴───────────┴─────────────────────────────────────────────┘
 
  Key Findings:
-  [HIGH] Provenance is intermittent across versions
-  [MEDIUM] Mixed publishing methods detected
   [CRITICAL] Single maintainer with full publish access
-  [HIGH] All maintainers using personal email addresses
-  [MEDIUM] Unscoped package with limited maintainer access
   [CRITICAL] Extremely high blast radius
   [CRITICAL] Maintainer email changed between versions
+  [HIGH] Provenance is intermittent across versions
+  [HIGH] All maintainers using personal email addresses
   [HIGH] Unknown publisher on recent version
-  [LOW] Multiple different publishers across recent versions
-  [MEDIUM] OpenSSF Scorecard: 5.5/10
   [HIGH] Scorecard Token-Permissions: 0/10
   [HIGH] Scorecard Pinned-Dependencies: 1/10
+  [MEDIUM] Mixed publishing methods detected
+  [MEDIUM] Unscoped package with limited maintainer access
+  [MEDIUM] OpenSSF Scorecard: 5.5/10
+  [LOW] Multiple different publishers across recent versions
 ```
 
 ## Signals
@@ -83,7 +83,9 @@ The score indicates how attractive a package is as a target, not whether it is c
 | Command | Description |
 |---|---|
 | `chainrecon scan <package>` | Scan an npm package |
-| `chainrecon watch` | Monitor packages for new versions |
+| `chainrecon diff <package>` | Diff two versions for suspicious changes |
+| `chainrecon watch [packages...]` | Monitor packages for new versions |
+| `chainrecon update` | Update chainrecon to the latest release |
 | `chainrecon version` | Print version info |
 
 ### scan flags

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -3,6 +3,7 @@ package output
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -83,9 +84,10 @@ func (t *TableFormatter) renderHeader(report *model.Report) string {
 
 // signalRow holds the data for a single signal table row.
 type signalRow struct {
-	signal string
-	score  string
-	detail string
+	signal   string
+	score    string
+	numScore float64
+	detail   string
 }
 
 // renderSignalTable draws the bordered table of signal scores and summary.
@@ -129,13 +131,25 @@ func (t *TableFormatter) buildSignalRows(report *model.Report) []signalRow {
 	}
 
 	rows := []signalRow{
-		{signal: "Provenance", score: fmt.Sprintf("%.1f/10", report.Scores.Provenance), detail: detailBySignal["provenance"]},
-		{signal: "Publishing Hygiene", score: fmt.Sprintf("%.1f/10", report.Scores.PublishingHygiene), detail: detailBySignal["publishing_hygiene"]},
-		{signal: "Maintainer Risk", score: fmt.Sprintf("%.1f/10", report.Scores.MaintainerRisk), detail: detailBySignal["maintainer_risk"]},
-		{signal: "Identity Stability", score: fmt.Sprintf("%.1f/10", report.Scores.IdentityStability), detail: detailBySignal["identity"]},
-		{signal: "Scorecard (imported)", score: fmt.Sprintf("%.1f/10", report.Scores.ScorecardRepo), detail: detailBySignal["scorecard"]},
-		{signal: "Blast Radius", score: fmt.Sprintf("%.1f/10", report.Scores.BlastRadius), detail: detailBySignal["blast_radius"]},
+		{signal: "Provenance", numScore: report.Scores.Provenance, score: fmt.Sprintf("%.1f/10", report.Scores.Provenance), detail: detailBySignal["provenance"]},
+		{signal: "Publishing Hygiene", numScore: report.Scores.PublishingHygiene, score: fmt.Sprintf("%.1f/10", report.Scores.PublishingHygiene), detail: detailBySignal["publishing_hygiene"]},
+		{signal: "Maintainer Risk", numScore: report.Scores.MaintainerRisk, score: fmt.Sprintf("%.1f/10", report.Scores.MaintainerRisk), detail: detailBySignal["maintainer_risk"]},
+		{signal: "Identity Stability", numScore: report.Scores.IdentityStability, score: fmt.Sprintf("%.1f/10", report.Scores.IdentityStability), detail: detailBySignal["identity"]},
+		{signal: "Scorecard (imported)", numScore: report.Scores.ScorecardRepo, score: fmt.Sprintf("%.1f/10", report.Scores.ScorecardRepo), detail: detailBySignal["scorecard"]},
+		{signal: "Blast Radius", numScore: report.Scores.BlastRadius, score: fmt.Sprintf("%.1f/10", report.Scores.BlastRadius), detail: detailBySignal["blast_radius"]},
 	}
+
+	// Sort by score descending so the highest-risk signals appear first.
+	slices.SortStableFunc(rows, func(a, b signalRow) int {
+		if a.numScore > b.numScore {
+			return -1
+		}
+		if a.numScore < b.numScore {
+			return 1
+		}
+		return 0
+	})
+
 	return rows
 }
 


### PR DESCRIPTION
Sort scan signal table rows by score (highest risk first). Slim smoke test from 11 packages to 1 with output validation. Add concurrency groups to CI workflows to cancel stale runs.