### PR TITLE
chore: update repo references to jakeva org

### DIFF
--- a/.github/examples/scan-on-pr.yml
+++ b/.github/examples/scan-on-pr.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   scan:
-    uses: chainrecon/chainrecon/.github/workflows/scan-deps.yml@main
+    uses: jakeva/chainrecon/.github/workflows/scan-deps.yml@main
     with:
       threshold: 50
     secrets:

--- a/.github/examples/watch-cron.yml
+++ b/.github/examples/watch-cron.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   watch:
-    uses: chainrecon/chainrecon/.github/workflows/watch-schedule.yml@main
+    uses: jakeva/chainrecon/.github/workflows/watch-schedule.yml@main
     with:
       config-path: .chainrecon.yml
     secrets:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,9 +7,9 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       - -s -w
-      - -X github.com/chainrecon/chainrecon/internal/cli.Version={{.Version}}
-      - -X github.com/chainrecon/chainrecon/internal/cli.Commit={{.Commit}}
-      - -X github.com/chainrecon/chainrecon/internal/cli.Date={{.Date}}
+      - -X github.com/jakeva/chainrecon/internal/cli.Version={{.Version}}
+      - -X github.com/jakeva/chainrecon/internal/cli.Commit={{.Commit}}
+      - -X github.com/jakeva/chainrecon/internal/cli.Date={{.Date}}
     goos:
       - linux
       - darwin
@@ -46,7 +46,7 @@ brews:
       owner: chainrecon
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    homepage: https://github.com/chainrecon/chainrecon
+    homepage: https://github.com/jakeva/chainrecon
     description: Find the next supply chain attack before the attacker does.
     license: Apache-2.0
     install: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Getting started
 
 ```bash
-git clone https://github.com/chainrecon/chainrecon.git
+git clone https://github.com/jakeva/chainrecon.git
 cd chainrecon
 make build
 make test

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 [![Go](https://img.shields.io/badge/Go-1.26-00ADD8?logo=go)](https://go.dev)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![CI](https://github.com/chainrecon/chainrecon/actions/workflows/ci.yml/badge.svg)](https://github.com/chainrecon/chainrecon/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/chainrecon/chainrecon)](https://github.com/chainrecon/chainrecon/releases/latest)
-[![Homebrew](https://img.shields.io/badge/Homebrew-chainrecon%2Ftap-FBB040?logo=homebrew)](https://github.com/chainrecon/homebrew-tap)
+[![CI](https://github.com/jakeva/chainrecon/actions/workflows/ci.yml/badge.svg)](https://github.com/jakeva/chainrecon/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/chainrecon/chainrecon)](https://github.com/jakeva/chainrecon/releases/latest)
+[![Homebrew](https://img.shields.io/badge/Homebrew-chainrecon%2Ftap-FBB040?logo=homebrew)](https://github.com/jakeva/homebrew-tap)
 
 chainrecon profiles npm packages from the attacker's perspective, surfacing the signals that make a package an attractive target for compromise before an attack happens.
 
@@ -116,7 +116,7 @@ The score indicates how attractive a package is as a target, not whether it is c
 ## Build from source
 
 ```bash
-git clone https://github.com/chainrecon/chainrecon.git
+git clone https://github.com/jakeva/chainrecon.git
 cd chainrecon
 make build
 ./bin/chainrecon scan axios


### PR DESCRIPTION
Fixes all GitHub URLs and brew tap references following the transfer from the chainrecon org.