### PR TITLE
chore: update Go module path and all references to jakeva org

### DIFF
--- a/.github/examples/scan-on-pr.yml
+++ b/.github/examples/scan-on-pr.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   scan:
-    uses: chainrecon/chainrecon/.github/workflows/scan-deps.yml@main
+    uses: jakeva/chainrecon/.github/workflows/scan-deps.yml@main
     with:
       threshold: 50
     secrets:

--- a/.github/examples/watch-cron.yml
+++ b/.github/examples/watch-cron.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   watch:
-    uses: chainrecon/chainrecon/.github/workflows/watch-schedule.yml@main
+    uses: jakeva/chainrecon/.github/workflows/watch-schedule.yml@main
     with:
       config-path: .chainrecon.yml
     secrets:

--- a/.github/workflows/scan-deps.yml
+++ b/.github/workflows/scan-deps.yml
@@ -35,7 +35,7 @@ jobs:
           go-version: "1.26"
 
       - name: Install chainrecon
-        run: go install github.com/chainrecon/chainrecon/cmd/chainrecon@${{ inputs.chainrecon-version }}
+        run: go install github.com/jakeva/chainrecon/cmd/chainrecon@${{ inputs.chainrecon-version }}
 
       - name: Detect changed packages
         id: detect

--- a/.github/workflows/watch-schedule.yml
+++ b/.github/workflows/watch-schedule.yml
@@ -31,7 +31,7 @@ jobs:
           go-version: "1.26"
 
       - name: Install chainrecon
-        run: go install github.com/chainrecon/chainrecon/cmd/chainrecon@latest
+        run: go install github.com/jakeva/chainrecon/cmd/chainrecon@latest
 
       - name: Pull state from chainrecon-state branch
         run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,9 +7,9 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       - -s -w
-      - -X github.com/chainrecon/chainrecon/internal/cli.Version={{.Version}}
-      - -X github.com/chainrecon/chainrecon/internal/cli.Commit={{.Commit}}
-      - -X github.com/chainrecon/chainrecon/internal/cli.Date={{.Date}}
+      - -X github.com/jakeva/chainrecon/internal/cli.Version={{.Version}}
+      - -X github.com/jakeva/chainrecon/internal/cli.Commit={{.Commit}}
+      - -X github.com/jakeva/chainrecon/internal/cli.Date={{.Date}}
     goos:
       - linux
       - darwin
@@ -46,7 +46,7 @@ brews:
       owner: chainrecon
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    homepage: https://github.com/chainrecon/chainrecon
+    homepage: https://github.com/jakeva/chainrecon
     description: Find the next supply chain attack before the attacker does.
     license: Apache-2.0
     install: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Getting started
 
 ```bash
-git clone https://github.com/chainrecon/chainrecon.git
+git clone https://github.com/jakeva/chainrecon.git
 cd chainrecon
 make build
 make test

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 DATE    ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-LDFLAGS := -X github.com/chainrecon/chainrecon/internal/cli.Version=$(VERSION) \
-           -X github.com/chainrecon/chainrecon/internal/cli.Commit=$(COMMIT) \
-           -X github.com/chainrecon/chainrecon/internal/cli.Date=$(DATE)
+LDFLAGS := -X github.com/jakeva/chainrecon/internal/cli.Version=$(VERSION) \
+           -X github.com/jakeva/chainrecon/internal/cli.Commit=$(COMMIT) \
+           -X github.com/jakeva/chainrecon/internal/cli.Date=$(DATE)
 
 .DEFAULT_GOAL := build
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 [![Go](https://img.shields.io/badge/Go-1.26-00ADD8?logo=go)](https://go.dev)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![CI](https://github.com/chainrecon/chainrecon/actions/workflows/ci.yml/badge.svg)](https://github.com/chainrecon/chainrecon/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/chainrecon/chainrecon)](https://github.com/chainrecon/chainrecon/releases/latest)
+[![CI](https://github.com/jakeva/chainrecon/actions/workflows/ci.yml/badge.svg)](https://github.com/jakeva/chainrecon/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/jakeva/chainrecon)](https://github.com/jakeva/chainrecon/releases/latest)
 [![Homebrew](https://img.shields.io/badge/Homebrew-chainrecon%2Ftap-FBB040?logo=homebrew)](https://github.com/chainrecon/homebrew-tap)
 
 chainrecon profiles npm packages from the attacker's perspective, surfacing the signals that make a package an attractive target for compromise before an attack happens.
@@ -116,7 +116,7 @@ The score indicates how attractive a package is as a target, not whether it is c
 ## Build from source
 
 ```bash
-git clone https://github.com/chainrecon/chainrecon.git
+git clone https://github.com/jakeva/chainrecon.git
 cd chainrecon
 make build
 ./bin/chainrecon scan axios

--- a/cmd/chainrecon/main.go
+++ b/cmd/chainrecon/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/chainrecon/chainrecon/internal/cli"
+	"github.com/jakeva/chainrecon/internal/cli"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/chainrecon/chainrecon
+module github.com/jakeva/chainrecon
 
 go 1.26.1
 

--- a/internal/alert/alert.go
+++ b/internal/alert/alert.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // Event holds the details of an alert that should be sent to notification backends.

--- a/internal/alert/alert_test.go
+++ b/internal/alert/alert_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 func testEvent() Event {

--- a/internal/analyzer/blast.go
+++ b/internal/analyzer/blast.go
@@ -5,8 +5,8 @@ import (
 	"math"
 	"strings"
 
-	"github.com/chainrecon/chainrecon/internal/format"
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/format"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // BlastRadiusAnalyzer evaluates the ecosystem impact of a compromised package

--- a/internal/analyzer/blast_test.go
+++ b/internal/analyzer/blast_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 func TestBlastRadiusAnalyzer(t *testing.T) {

--- a/internal/analyzer/contextual.go
+++ b/internal/analyzer/contextual.go
@@ -3,7 +3,7 @@ package analyzer
 import (
 	"math"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // Severity weights for code findings when computing a composite code risk score.

--- a/internal/analyzer/contextual_test.go
+++ b/internal/analyzer/contextual_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 func TestScoreCodeFindings_Empty(t *testing.T) {

--- a/internal/analyzer/credential.go
+++ b/internal/analyzer/credential.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // CredentialAnalyzer detects code that reads credentials or sensitive files.

--- a/internal/analyzer/credential_test.go
+++ b/internal/analyzer/credential_test.go
@@ -3,7 +3,7 @@ package analyzer
 import (
 	"testing"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 func TestCredentialAnalyzer(t *testing.T) {

--- a/internal/analyzer/depinjection.go
+++ b/internal/analyzer/depinjection.go
@@ -3,7 +3,7 @@ package analyzer
 import (
 	"fmt"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // DepInjectionAnalyzer detects new dependencies added between two versions

--- a/internal/analyzer/depinjection_test.go
+++ b/internal/analyzer/depinjection_test.go
@@ -3,7 +3,7 @@ package analyzer
 import (
 	"testing"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 func TestDepInjectionAnalyzer(t *testing.T) {

--- a/internal/analyzer/hygiene.go
+++ b/internal/analyzer/hygiene.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // HygieneAnalyzer evaluates the publishing hygiene of an npm package by

--- a/internal/analyzer/hygiene_test.go
+++ b/internal/analyzer/hygiene_test.go
@@ -3,7 +3,7 @@ package analyzer
 import (
 	"testing"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 func TestHygieneAnalyzer_AllTrustedPublishing(t *testing.T) {

--- a/internal/analyzer/identity.go
+++ b/internal/analyzer/identity.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // IdentityAnalyzer evaluates the stability of publisher identity across

--- a/internal/analyzer/identity_test.go
+++ b/internal/analyzer/identity_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 func TestIdentityAnalyzer_StableIdentity(t *testing.T) {

--- a/internal/analyzer/lifecycle.go
+++ b/internal/analyzer/lifecycle.go
@@ -3,7 +3,7 @@ package analyzer
 import (
 	"fmt"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // LifecycleAnalyzer detects newly added or modified lifecycle scripts in

--- a/internal/analyzer/lifecycle_test.go
+++ b/internal/analyzer/lifecycle_test.go
@@ -3,7 +3,7 @@ package analyzer
 import (
 	"testing"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 func TestLifecycleAnalyzer(t *testing.T) {

--- a/internal/analyzer/maintainer.go
+++ b/internal/analyzer/maintainer.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // MaintainerAnalyzer evaluates the risk posed by the concentration and

--- a/internal/analyzer/maintainer_test.go
+++ b/internal/analyzer/maintainer_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 func TestMaintainerAnalyzer_SingleMaintainerPersonalEmail_Unscoped(t *testing.T) {

--- a/internal/analyzer/nativeaddon.go
+++ b/internal/analyzer/nativeaddon.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // NativeAddonAnalyzer detects the addition of native binaries, shared

--- a/internal/analyzer/nativeaddon_test.go
+++ b/internal/analyzer/nativeaddon_test.go
@@ -3,7 +3,7 @@ package analyzer
 import (
 	"testing"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 func TestNativeAddonAnalyzer(t *testing.T) {

--- a/internal/analyzer/network.go
+++ b/internal/analyzer/network.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // NetworkAnalyzer detects introduction of network capabilities in JS/TS files.

--- a/internal/analyzer/network_test.go
+++ b/internal/analyzer/network_test.go
@@ -3,7 +3,7 @@ package analyzer
 import (
 	"testing"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 func TestNetworkAnalyzer(t *testing.T) {

--- a/internal/analyzer/obfuscation.go
+++ b/internal/analyzer/obfuscation.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // ObfuscationAnalyzer scans added or modified JS/TS files for patterns that

--- a/internal/analyzer/obfuscation_test.go
+++ b/internal/analyzer/obfuscation_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 func TestObfuscationAnalyzer(t *testing.T) {

--- a/internal/analyzer/provenance.go
+++ b/internal/analyzer/provenance.go
@@ -4,7 +4,7 @@ package analyzer
 import (
 	"fmt"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // ProvenanceAnalyzer evaluates provenance attestation history for a package

--- a/internal/analyzer/provenance_test.go
+++ b/internal/analyzer/provenance_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // almostEqual reports whether two float64 values are within the given tolerance.

--- a/internal/analyzer/scorecard.go
+++ b/internal/analyzer/scorecard.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // ScorecardAnalyzer evaluates a package's repository security posture

--- a/internal/analyzer/scorecard_test.go
+++ b/internal/analyzer/scorecard_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 func TestScorecardAnalyzer_NilResult(t *testing.T) {

--- a/internal/analyzer/scorer.go
+++ b/internal/analyzer/scorer.go
@@ -3,7 +3,7 @@ package analyzer
 import (
 	"math"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // Weights for attack_surface_score.

--- a/internal/analyzer/scorer_test.go
+++ b/internal/analyzer/scorer_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 func TestScorer_ComputeScores(t *testing.T) {

--- a/internal/analyzer/tagcorrelation.go
+++ b/internal/analyzer/tagcorrelation.go
@@ -5,7 +5,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // TagCorrelationAnalyzer detects npm versions that were published without

--- a/internal/analyzer/tagcorrelation_test.go
+++ b/internal/analyzer/tagcorrelation_test.go
@@ -3,7 +3,7 @@ package analyzer
 import (
 	"testing"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 func TestTagCorrelationAnalyzer_AllMatched(t *testing.T) {

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/chainrecon/chainrecon/internal/collector/npm"
-	pkgdiff "github.com/chainrecon/chainrecon/internal/diff"
+	"github.com/jakeva/chainrecon/internal/collector/npm"
+	pkgdiff "github.com/jakeva/chainrecon/internal/diff"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/chainrecon/chainrecon/internal/output"
-	"github.com/chainrecon/chainrecon/internal/scan"
+	"github.com/jakeva/chainrecon/internal/output"
+	"github.com/jakeva/chainrecon/internal/scan"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/scan_integration_test.go
+++ b/internal/cli/scan_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // TestIntegration_Scan runs a real scan against a package and validates

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -108,7 +108,7 @@ func isHomebrewPath(path string) bool {
 
 func fetchLatestRelease(ctx context.Context) (*ghRelease, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
-		"https://api.github.com/repos/chainrecon/chainrecon/releases/latest", nil)
+		"https://api.github.com/repos/jakeva/chainrecon/releases/latest", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -7,12 +7,12 @@ import (
 	"os/signal"
 	"time"
 
-	"github.com/chainrecon/chainrecon/internal/alert"
-	"github.com/chainrecon/chainrecon/internal/collector/npm"
-	"github.com/chainrecon/chainrecon/internal/scan"
-	"github.com/chainrecon/chainrecon/internal/state"
-	"github.com/chainrecon/chainrecon/internal/watch"
-	"github.com/chainrecon/chainrecon/internal/watchlist"
+	"github.com/jakeva/chainrecon/internal/alert"
+	"github.com/jakeva/chainrecon/internal/collector/npm"
+	"github.com/jakeva/chainrecon/internal/scan"
+	"github.com/jakeva/chainrecon/internal/state"
+	"github.com/jakeva/chainrecon/internal/watch"
+	"github.com/jakeva/chainrecon/internal/watchlist"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/collector/github/client.go
+++ b/internal/collector/github/client.go
@@ -12,9 +12,9 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/chainrecon/chainrecon/internal/cache"
-	"github.com/chainrecon/chainrecon/internal/collector"
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/cache"
+	"github.com/jakeva/chainrecon/internal/collector"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 var apiBaseURL = "https://api.github.com"

--- a/internal/collector/github/repo.go
+++ b/internal/collector/github/repo.go
@@ -3,7 +3,7 @@ package github
 import (
 	"strings"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // ParseRepoURL extracts the GitHub owner and repo name from npm package

--- a/internal/collector/github/repo_test.go
+++ b/internal/collector/github/repo_test.go
@@ -3,7 +3,7 @@ package github
 import (
 	"testing"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 func TestParseRepoURL(t *testing.T) {

--- a/internal/collector/npm/attestation.go
+++ b/internal/collector/npm/attestation.go
@@ -13,9 +13,9 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"github.com/chainrecon/chainrecon/internal/cache"
-	"github.com/chainrecon/chainrecon/internal/collector"
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/cache"
+	"github.com/jakeva/chainrecon/internal/collector"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 var attestationBaseURL = "https://registry.npmjs.org/-/npm/v1/attestations"

--- a/internal/collector/npm/attestation_test.go
+++ b/internal/collector/npm/attestation_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/chainrecon/chainrecon/internal/cache"
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/cache"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 func newTestAttestationClient(t *testing.T, server *httptest.Server) *attestationClient {

--- a/internal/collector/npm/maintainer.go
+++ b/internal/collector/npm/maintainer.go
@@ -4,7 +4,7 @@ package npm
 import (
 	"strings"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // MaintainerClient provides analysis of npm package maintainer metadata.

--- a/internal/collector/npm/maintainer_test.go
+++ b/internal/collector/npm/maintainer_test.go
@@ -3,7 +3,7 @@ package npm
 import (
 	"testing"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 func TestMaintainerClient_ExtractMaintainers(t *testing.T) {

--- a/internal/collector/npm/poller.go
+++ b/internal/collector/npm/poller.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/chainrecon/chainrecon/internal/collector"
+	"github.com/jakeva/chainrecon/internal/collector"
 )
 
 // Poller checks for new versions of npm packages using conditional HTTP requests.

--- a/internal/collector/npm/registry.go
+++ b/internal/collector/npm/registry.go
@@ -12,9 +12,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/chainrecon/chainrecon/internal/cache"
-	"github.com/chainrecon/chainrecon/internal/collector"
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/cache"
+	"github.com/jakeva/chainrecon/internal/collector"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 var (

--- a/internal/collector/npm/registry_test.go
+++ b/internal/collector/npm/registry_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/chainrecon/chainrecon/internal/cache"
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/cache"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // newTestRegistryClient builds a registryClient pointed at the given test server.

--- a/internal/collector/npm/tarball.go
+++ b/internal/collector/npm/tarball.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/chainrecon/chainrecon/internal/collector"
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/collector"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 const (

--- a/internal/collector/scorecard/client.go
+++ b/internal/collector/scorecard/client.go
@@ -10,9 +10,9 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/chainrecon/chainrecon/internal/cache"
-	"github.com/chainrecon/chainrecon/internal/collector"
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/cache"
+	"github.com/jakeva/chainrecon/internal/collector"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 var baseURL = "https://api.scorecard.dev/projects"

--- a/internal/collector/scorecard/client_test.go
+++ b/internal/collector/scorecard/client_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 func TestFetchScore_Success(t *testing.T) {

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // Compare produces a ReleaseDiff from two PackageContents.

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 func makeContents(name, version string, files map[string]string) *model.PackageContents {

--- a/internal/diff/pipeline.go
+++ b/internal/diff/pipeline.go
@@ -1,8 +1,8 @@
 package diff
 
 import (
-	"github.com/chainrecon/chainrecon/internal/analyzer"
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/analyzer"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // Analysis holds the results of running all code analyzers on a release diff.

--- a/internal/diff/pipeline_test.go
+++ b/internal/diff/pipeline_test.go
@@ -3,7 +3,7 @@ package diff
 import (
 	"testing"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 func TestAnalyze_NoFindings(t *testing.T) {

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // Formatter defines the interface for rendering a Report to a string.

--- a/internal/output/json_test.go
+++ b/internal/output/json_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // sampleJSONReport builds a fully-populated report for JSON formatting tests.

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // SARIFFormatter renders a Report as SARIF 2.1.0 JSON for GitHub code scanning.

--- a/internal/output/sarif_test.go
+++ b/internal/output/sarif_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 func sampleSARIFReport() *model.Report {

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/chainrecon/chainrecon/internal/analyzer"
-	"github.com/chainrecon/chainrecon/internal/format"
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/analyzer"
+	"github.com/jakeva/chainrecon/internal/format"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // Column widths for the signal table.

--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // sampleReport builds a fully-populated report for table formatting tests.

--- a/internal/scan/pipeline.go
+++ b/internal/scan/pipeline.go
@@ -9,12 +9,12 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"github.com/chainrecon/chainrecon/internal/analyzer"
-	"github.com/chainrecon/chainrecon/internal/cache"
-	gh "github.com/chainrecon/chainrecon/internal/collector/github"
-	"github.com/chainrecon/chainrecon/internal/collector/npm"
-	"github.com/chainrecon/chainrecon/internal/collector/scorecard"
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/analyzer"
+	"github.com/jakeva/chainrecon/internal/cache"
+	gh "github.com/jakeva/chainrecon/internal/collector/github"
+	"github.com/jakeva/chainrecon/internal/collector/npm"
+	"github.com/jakeva/chainrecon/internal/collector/scorecard"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // Options configures a scan pipeline run.

--- a/internal/watch/diff.go
+++ b/internal/watch/diff.go
@@ -6,10 +6,10 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/chainrecon/chainrecon/internal/cache"
-	"github.com/chainrecon/chainrecon/internal/collector/npm"
-	pkgdiff "github.com/chainrecon/chainrecon/internal/diff"
-	"github.com/chainrecon/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/cache"
+	"github.com/jakeva/chainrecon/internal/collector/npm"
+	pkgdiff "github.com/jakeva/chainrecon/internal/diff"
+	"github.com/jakeva/chainrecon/internal/model"
 )
 
 // DefaultDiffFunc returns a DiffFunc that downloads tarballs and runs the

--- a/internal/watch/runner.go
+++ b/internal/watch/runner.go
@@ -7,13 +7,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/chainrecon/chainrecon/internal/alert"
-	"github.com/chainrecon/chainrecon/internal/analyzer"
-	"github.com/chainrecon/chainrecon/internal/collector/npm"
-	"github.com/chainrecon/chainrecon/internal/model"
-	"github.com/chainrecon/chainrecon/internal/scan"
-	"github.com/chainrecon/chainrecon/internal/state"
-	"github.com/chainrecon/chainrecon/internal/watchlist"
+	"github.com/jakeva/chainrecon/internal/alert"
+	"github.com/jakeva/chainrecon/internal/analyzer"
+	"github.com/jakeva/chainrecon/internal/collector/npm"
+	"github.com/jakeva/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/scan"
+	"github.com/jakeva/chainrecon/internal/state"
+	"github.com/jakeva/chainrecon/internal/watchlist"
 )
 
 // ScanFunc runs a scan and returns the report.

--- a/internal/watch/runner_integration_test.go
+++ b/internal/watch/runner_integration_test.go
@@ -7,10 +7,10 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/chainrecon/chainrecon/internal/collector/npm"
-	"github.com/chainrecon/chainrecon/internal/model"
-	"github.com/chainrecon/chainrecon/internal/state"
-	"github.com/chainrecon/chainrecon/internal/watchlist"
+	"github.com/jakeva/chainrecon/internal/collector/npm"
+	"github.com/jakeva/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/state"
+	"github.com/jakeva/chainrecon/internal/watchlist"
 )
 
 // TestRunOnce_StatePersistsAcrossRuns verifies that when we save state after

--- a/internal/watch/runner_test.go
+++ b/internal/watch/runner_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/chainrecon/chainrecon/internal/alert"
-	"github.com/chainrecon/chainrecon/internal/collector/npm"
-	"github.com/chainrecon/chainrecon/internal/model"
-	"github.com/chainrecon/chainrecon/internal/state"
-	"github.com/chainrecon/chainrecon/internal/watchlist"
+	"github.com/jakeva/chainrecon/internal/alert"
+	"github.com/jakeva/chainrecon/internal/collector/npm"
+	"github.com/jakeva/chainrecon/internal/model"
+	"github.com/jakeva/chainrecon/internal/state"
+	"github.com/jakeva/chainrecon/internal/watchlist"
 )
 
 type fakePoller struct {


### PR DESCRIPTION
Updates go.mod module path from `github.com/chainrecon/chainrecon` to `github.com/jakeva/chainrecon` and fixes all import paths, ldflags, GitHub API URLs, and documentation references. All tests pass.