### PR TITLE
chore: fix final org references in goreleaser and install command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,7 +43,7 @@ changelog:
 
 brews:
   - repository:
-      owner: chainrecon
+      owner: jakeva
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     homepage: https://github.com/jakeva/chainrecon

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![CI](https://github.com/jakeva/chainrecon/actions/workflows/ci.yml/badge.svg)](https://github.com/jakeva/chainrecon/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/jakeva/chainrecon)](https://github.com/jakeva/chainrecon/releases/latest)
-[![Homebrew](https://img.shields.io/badge/Homebrew-chainrecon%2Ftap-FBB040?logo=homebrew)](https://github.com/chainrecon/homebrew-tap)
+[![Homebrew](https://img.shields.io/badge/Homebrew-jakeva%2Ftap-FBB040?logo=homebrew)](https://github.com/jakeva/homebrew-tap)
 
 chainrecon profiles npm packages from the attacker's perspective, surfacing the signals that make a package an attractive target for compromise before an attack happens.
 
 ## Quick start
 
 ```
-$ brew install chainrecon/tap/chainrecon
+$ brew install jakeva/tap/chainrecon
 $ chainrecon scan axios
 
  Package: axios


### PR DESCRIPTION
Critical fixes for public sharing: GoReleaser now points to jakeva/homebrew-tap and README install command updated.